### PR TITLE
Fix accidental spam of Cannot get message of reaction

### DIFF
--- a/pkg/commands/help/help.go
+++ b/pkg/commands/help/help.go
@@ -115,7 +115,7 @@ func (h *HelpCommand) helpMenu() *embed.Embed {
 func (h *HelpCommand) handleHelpReaction(s *discordgo.Session, r *discordgo.MessageReactionAdd) {
 	message, err := s.ChannelMessage(r.ChannelID, r.MessageID)
 	if err != nil {
-		s.ChannelMessageSend(r.ChannelID, "Cannot get message of reaction")
+		log.Println("Cannot get message of reaction", r.ChannelID)
 		return
 	}
 


### PR DESCRIPTION
Sending this error in a channel was a terrible idea