### PR TITLE
/menu can now handle non http-200 response codes

### DIFF
--- a/pkg/commands/menu/menu.go
+++ b/pkg/commands/menu/menu.go
@@ -120,6 +120,21 @@ func (h *MenuCommand) SayMenu(s *discordgo.Session, i *discordgo.InteractionCrea
 	var selectedCampus = i.ApplicationCommandData().Options[0].Value.(string)
 
 	data := GetSiteContent(selectedCampus)
+
+	if data == nil {
+		err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "We can't get the menu at this time, try again later",
+			},
+		})
+
+		if err != nil {
+			log.Println(err)
+		}
+		return
+	}
+
 	if len(data) == 0 {
 		err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
@@ -241,6 +256,9 @@ func GetSiteContent(campus string) []interface{} {
 	res, err := http.Get(apiString + campus)
 	if err != nil {
 		log.Fatalf(err.Error())
+	}
+	if res.StatusCode != 200 {
+		return nil
 	}
 
 	content, err := ioutil.ReadAll(res.Body)

--- a/pkg/commands/menu/menu.go
+++ b/pkg/commands/menu/menu.go
@@ -232,6 +232,20 @@ func (h *MenuCommand) SayMenu(s *discordgo.Session, i *discordgo.InteractionCrea
 		}
 	}
 
+	if len(embeds) == 0 {
+		err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "That campus does not have a menu for this week yet!",
+			},
+		})
+
+		if err != nil {
+			log.Println(err)
+		}
+		return
+	}
+
 	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{


### PR DESCRIPTION
By adding a single if-statement, the user can have a much better experience when encountering an error caused by http error codes