### PR TITLE
Start & delete perms for gamerAdmins

### DIFF
--- a/pkg/commands/game/lookForPlayers.go
+++ b/pkg/commands/game/lookForPlayers.go
@@ -2,6 +2,7 @@ package game
 
 import (
 	"fmt"
+	"github.com/itfactory-tm/thomas-bot/pkg/sudo"
 	"log"
 	"regexp"
 	"strconv"
@@ -384,7 +385,8 @@ func (l *LookCommand) handleBtnClick(s *discordgo.Session, i *discordgo.Interact
 
 	hostID, neededPlayers, playersIDs, backupPlayersIDs := l.getPlayers(message)
 	_, activePlayers := l.buildBackup(message, playersIDs, neededPlayers)
-	if uid == hostID {
+	//If host of LFP or gamer admin
+	if (uid == hostID) || sudo.IsItfGameAdmin(uid) {
 		if i.MessageComponentData().CustomID == "lfp_delete" {
 			//Delete message first to prevent players being notified multiple times when emoji spam (Dirk proofing)
 			err := s.ChannelMessageDelete(i.ChannelID, i.Message.ID)
@@ -401,7 +403,7 @@ func (l *LookCommand) handleBtnClick(s *discordgo.Session, i *discordgo.Interact
 		if i.MessageComponentData().CustomID == "lfp_start" {
 			l.startGame(s, i, activePlayers, backupPlayersIDs, neededPlayers, message)
 		}
-	} else if i.MessageComponentData().CustomID == "lfp_delete" {
+	} else if i.MessageComponentData().CustomID == "lfp_delete" { //If delete was pressed as normal player
 		_, activePlayers, activeBackupPlayers, backupPlayers, _ := l.removePlayer(message, uid)
 		l.handleJoinReaction(activePlayers, activeBackupPlayers, backupPlayers, neededPlayers, message, s)
 		return

--- a/pkg/commands/game/lookForPlayers.go
+++ b/pkg/commands/game/lookForPlayers.go
@@ -386,7 +386,7 @@ func (l *LookCommand) handleBtnClick(s *discordgo.Session, i *discordgo.Interact
 	hostID, neededPlayers, playersIDs, backupPlayersIDs := l.getPlayers(message)
 	_, activePlayers := l.buildBackup(message, playersIDs, neededPlayers)
 	//If host of LFP or gamer admin
-	if (uid == hostID) || sudo.IsItfGameAdmin(uid) {
+	if uid == hostID || sudo.IsItfGameAdmin(uid) {
 		if i.MessageComponentData().CustomID == "lfp_delete" {
 			//Delete message first to prevent players being notified multiple times when emoji spam (Dirk proofing)
 			err := s.ChannelMessageDelete(i.ChannelID, i.Message.ID)

--- a/pkg/sudo/sudo.go
+++ b/pkg/sudo/sudo.go
@@ -22,7 +22,7 @@ func IsAdmin(userID string) bool {
 
 var itfGameAdmins = map[string]bool{
 	"161504618017325057": true, // Victor Welters
-	"434499632765075456": true, // Ward Beyens
+	"153480318328897536": true, // MystWizard (Mitchel Holemans)
 	"249632139228741632": true, // Brent (Allen?)
 	"252083102992695296": true, // Alex Coulon
 	"307916386238201856": true, // Jorne Marx


### PR DESCRIPTION
# Gamer admins can start & delete LFP's
Updated the sudo.go file with current gamer admins.
This is a requested feature from Dirk and other gamer admins.
Added some comments to make it clearer :)

![miem](https://user-images.githubusercontent.com/57660107/160212766-732f042b-b2c8-4d44-878a-88d44a398adc.jpg)

